### PR TITLE
Error handling protocol, and 204 status returning Empty

### DIFF
--- a/DDRouter.podspec
+++ b/DDRouter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'DDRouter'
-  spec.version      = '0.3.0'
+  spec.version      = '0.3.1'
   spec.license      = { :type => 'ISC' }
   spec.homepage     = 'https://hub.deloittedigital.com.au/stash/projects/DDMCD/repos/ddrouter/browse'
   spec.authors      = { 'Deloitte Digital' => 'wrigney@deloitte.com.au' }

--- a/DDRouter/DDRouter.swift
+++ b/DDRouter/DDRouter.swift
@@ -21,25 +21,6 @@ public protocol RouterProtocol {
     func request<T: Decodable>(_ route: Endpoint) -> Single<T>
 }
 
-public class RouterErrorProxy<Endpoint: EndpointType, E: APIErrorModelProtocol>: RouterProtocol {
-    var wrapped: Router<Endpoint, E>
-    public var onError: (_ error: Error) -> PrimitiveSequence<MaybeTrait, Int>
-    
-    public func request<T>(_ route: Endpoint) -> Single<T> where T : Decodable {
-        self.wrapped.request(route)
-        .retryWhen({ (error) -> Observable<Int> in
-            return error.flatMap({ error -> Maybe<Int> in
-                return self.onError(error)
-            })
-        })
-    }
-    
-    public init(wrapped: Router<Endpoint, E>, onError: @escaping ((_ error: Error) -> PrimitiveSequence<MaybeTrait, Int>)) {
-        self.wrapped = wrapped
-        self.onError = onError
-    }
-}
-
 public class Router<Endpoint: EndpointType, E: APIErrorModelProtocol>: RouterProtocol {
     var urlSession: URLSession?
 

--- a/DDRouter/DDRouter.swift
+++ b/DDRouter/DDRouter.swift
@@ -22,11 +22,14 @@ public protocol RouterProtocol {
     init(ephemeralSession: Bool)
 }
 
+public struct EmptyStruct: Decodable {}
+
+extension RouterProtocol {
+    public typealias Empty = EmptyStruct
+}
+
 public class Router<Endpoint: EndpointType, E: APIErrorModelProtocol>: RouterProtocol {
     var urlSession: URLSession?
-
-    // Just Void, which is a popular choice when forced to have _some_ type (plus it's primitive so : Decodable)
-    typealias Empty = Void
 
     required public init(ephemeralSession: Bool = false) {
         if ephemeralSession {


### PR DESCRIPTION
This helps clients to create their own wrapping implementations and ensure they conform to spec.

That's about it, removed isRelogin as there was a todo to remove it and nothing used it.